### PR TITLE
[packaging] Configuration package

### DIFF
--- a/bluetooth-rfkill-event/Makefile
+++ b/bluetooth-rfkill-event/Makefile
@@ -23,5 +23,6 @@ install:
 	install bluetooth_rfkill_event $(INSTALL_ROOT)/usr/sbin
 	mkdir -p $(INSTALL_ROOT)/lib/systemd/system
 	install bluetooth-rfkill-event.service $(INSTALL_ROOT)/lib/systemd/system
-	mkdir -p $(INSTALL_ROOT)/etc/firmware
-	install *.conf $(INSTALL_ROOT)/etc/firmware
+	mkdir -p $(INSTALL_ROOT)/etc/bluetooth-rfkill-event
+	mkdir -p $(INSTALL_ROOT)/etc/sysconfig
+	install bluetooth-rfkill-event.sysconfig $(INSTALL_ROOT)/etc/sysconfig/bluetooth-rfkill-event

--- a/bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig
+++ b/bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig
@@ -1,0 +1,4 @@
+# Can be used to configure the following:
+# DEBUG -- debug options
+# BTMODULE -- name of bluetooth kernel module to load/unload, if any
+# CONFIGFILE -- name of configuration file to use

--- a/rpm/bluetooth-rfkill-event.spec
+++ b/rpm/bluetooth-rfkill-event.spec
@@ -8,11 +8,20 @@ Source0: %{name}-%{version}.tar.bz2
 Requires: bluez-libs
 Requires: glib2
 Requires: broadcom-bluetooth
+Requires: bluetooth-rfkill-event-configs
 BuildRequires: bluez-libs-devel
 BuildRequires: glib2-devel
 
 %description
 Bluetooth rfkill event daemon. Part of Intel Edison GPL/LGPL sources.
+
+%package configs-mer
+Summary:    Default configuration for bluetooth-rfkill-event
+Requires:   %{name} = %{version}-%{release}
+Provides:   bluetooth-rfkill-event-configs
+
+%description configs-mer
+This package provides default configuration for bluetooth-rfkill-event
 
 %prep
 %setup -q -n %{name}-%{version}/bluetooth-rfkill-event
@@ -29,5 +38,11 @@ rm -rf %{buildroot}
 # >> files
 %{_sbindir}/bluetooth_rfkill_event
 /%{_lib}/systemd/system/bluetooth-rfkill-event.service
-%exclude %{_sysconfdir}/firmware/*.conf
 # << files
+
+%files configs-mer
+%defattr(-,root,root,-)
+# >> files configs-mer
+%dir %{_sysconfdir}/bluetooth-rfkill-event
+%{_sysconfdir}/sysconfig/bluetooth-rfkill-event
+# << files configs-mer


### PR DESCRIPTION
Added configuration package, which contains directory
/etc/bluetooth-rfkill-event for storing device-specific configuration
files, and /etc/sysconfig/bluetooth-rfkill-event for configuring
command line arguments used by systemd.
